### PR TITLE
build: Vercel SPA Fallback Routing 시 필요한 vercel.json 파일 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
- 폴더 내 라우팅 처리 시 Vercel은 정적 호스팅 방식이므로 SPA fallback 처리가 필요함